### PR TITLE
Parse TAP output for skipped tests.

### DIFF
--- a/cmake/BatsTest.cmake
+++ b/cmake/BatsTest.cmake
@@ -1,3 +1,21 @@
+##
+# @brief Discovers and registers tests from BATS scripts for use with CTest.
+#
+# This function extracts test names defined in the BATS script files and registers them as CTest tests. Each test is
+# associated with properties for passing, failing, and skipping, provided the version of CMake supports them.
+#
+# @param SCRIPT_FILES List of BATS script files to process.
+#
+# Requirements:
+# - CMake version 3.16 or later is required for `SKIP_REGULAR_EXPRESSION`.
+#
+# Limitations:
+# - BATS test case names cannot include characters that CMake would expand (e.g., `${}`).
+# - BATS test case names cannot contain regular expression syntax, as they may be mangled by the `--filter` option in BATS.
+# - Test case names must be globally unique.
+# - This function does not account for BATS test tags.
+# - The alternate test naming syntax (e.g., `function foo() {  # @test`) is not supported and may break this function.
+#
 function(bats_discover_tests SCRIPT_FILES)
     foreach (SCRIPT_FILE IN LISTS SCRIPT_FILES)
         if(NOT "${SCRIPT_FILE}" STREQUAL "")
@@ -8,8 +26,13 @@ function(bats_discover_tests SCRIPT_FILES)
                 MATH(EXPR firstQuoteIndex "${firstQuoteIndex}+1")
                 MATH(EXPR nameLength "${secondQuoteIndex}-${firstQuoteIndex}")
                 string(SUBSTRING ${TEST_LINE} ${firstQuoteIndex} ${nameLength} TEST_NAME)
+
                 add_test(NAME ${TEST_NAME}
-                        COMMAND ${bats_SOURCE_DIR}/bin/bats ${SCRIPT_FILE} -f "${TEST_NAME}")
+                        COMMAND ${bats_SOURCE_DIR}/bin/bats --formatter tap --filter "^${TEST_NAME}\$" ${SCRIPT_FILE})
+                set_tests_properties("${TEST_NAME}" PROPERTIES
+                        PASS_REGULAR_EXPRESSION "1\.\.1[\r\n\t ]+ok 1 ${TEST_NAME}[\r\n\t ]+$"
+                        FAIL_REGULAR_EXPRESSION "1\.\.1[\r\n\t ]+not ok 1 ${TEST_NAME}[\r\n\t ]+$"
+                        SKIP_REGULAR_EXPRESSION "1\.\.1[\r\n\t ]+ok 1 ${TEST_NAME} # skip[\r\n\t ]+$")
             endforeach()
         endif()
     endforeach()

--- a/sample-project/CMakeLists.txt
+++ b/sample-project/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.16)
 project(sample-project)
 
 add_executable(duplicator duplicator.cpp)

--- a/sample-project/test-edge-cases.bats
+++ b/sample-project/test-edge-cases.bats
@@ -11,3 +11,7 @@
   [ "$status" -eq 0 ]
   [ "$output" -gt "-2147483648" ]
 }
+
+@test "skip-it" {
+  skip
+}


### PR DESCRIPTION
This pull request allows the developer to add BATS test cases that are marked as skipped.  Without it, the test appears as "passed" in the ctest output, resulting in a misleading test result.  Rather, it should appear as "**skipped**" in the ctest output.  The fix for this problem was implemented with the [`SKIP_REGULAR_EXPRESSION`](https://cmake.org/cmake/help/latest/prop_test/SKIP_REGULAR_EXPRESSION.html) cmake variable.  An unfortunate side effect is that versions of cmake earlier than 3.16, regular expressions were processed differently and would result in a syntax error.

Furthermore, this PR makes a small change that ensures that only one test is executed.  The `--filter` argument to bats accepts a regular expression.  When adding `--filter "${TEST_NAME}"`, there is a possibility that the regex can result in more than one test case.  For example, `--filter "negative-number"` is resolved to two test cases being executed: `negative-number` and `large-negative-number` (this can be verified when running `ctest -V` in the build directory).  This is resolved by changing the bats filter argument to `--filter "^${TEST_NAME}\$"`.