### PR TITLE
feat: add top-level CMakeLists.txt for compatibility with CPM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,3 @@
+include_guard()
+
+include("${CMAKE_CURRENT_LIST_DIR}/cmake/BatsTest.cmake")


### PR DESCRIPTION
This PR adds support for [CPM](https://github.com/cpm-cmake/CPM.cmake). The cmake-package-manager needs a top-level CMakeLists.txt file.

This change enables a client of this helper to use e.g.:

CPMAddPackage("gh:neonsoftware/cmake-bats@0.0.2")