### PR TITLE
feat: add DEF_SOURCE_LINE to enable "Go to test"

### DIFF
--- a/cmake/BatsTest.cmake
+++ b/cmake/BatsTest.cmake
@@ -32,12 +32,17 @@ function(bats_discover_tests SCRIPT_FILES)
                 MATH(EXPR nameLength "${secondQuoteIndex}-${firstQuoteIndex}")
                 string(SUBSTRING ${TEST_LINE} ${firstQuoteIndex} ${nameLength} TEST_NAME)
 
+                file(STRINGS ${SCRIPT_FILE} ALL_LINES)
+                list(FIND ALL_LINES "${TEST_LINE}" LINE_NUMBER)
+                MATH(EXPR LINE_NUMBER "${LINE_NUMBER}+1")
+
                 add_test(NAME ${TEST_NAME}
                         COMMAND ${BATS} --formatter tap --filter "^${TEST_NAME}\$" ${SCRIPT_FILE})
                 set_tests_properties("${TEST_NAME}" PROPERTIES
                         PASS_REGULAR_EXPRESSION "1\.\.1[\r\n\t ]+ok 1 ${TEST_NAME}[\r\n\t ]+$"
                         FAIL_REGULAR_EXPRESSION "1\.\.1[\r\n\t ]+not ok 1 ${TEST_NAME}[\r\n\t ]+$"
-                        SKIP_REGULAR_EXPRESSION "1\.\.1[\r\n\t ]+ok 1 ${TEST_NAME} # skip[\r\n\t ]+$")
+                        SKIP_REGULAR_EXPRESSION "1\.\.1[\r\n\t ]+ok 1 ${TEST_NAME} # skip[\r\n\t ]+$"
+                        DEF_SOURCE_LINE "${SCRIPT_FILE}:${LINE_NUMBER}")
             endforeach()
         endif()
     endforeach()


### PR DESCRIPTION
This PR adds support for a "richer" test experience by adding the DEF_SOURCE_LINE property on all tests. This property is filled with the source:line of each test and enables "Go to test" from the test explorer and adds test-icons in the gutter for the test files.

Please note that this will not work until my PR https://github.com/microsoft/vscode-cmake-tools/pull/4321 is merged.